### PR TITLE
feat: Show branch name in window title and header

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -46,6 +46,14 @@ header h1 {
   min-width: 0;
 }
 
+/* Branch indicator for non-main branches */
+.branch-indicator {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #fbbf24;
+  opacity: 0.9;
+}
+
 header nav {
   display: flex;
   align-items: center;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Route, Routes } from 'react-router-dom';
+import { GIT_BRANCH } from '../generated_version';
 import { SwingAnalyzerProvider } from '../contexts/SwingAnalyzerContext';
 import AnalysisSection from './AnalysisSection';
 import VideoSection from './VideoSection';
@@ -47,6 +48,10 @@ const isMac =
   navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 const bugReportShortcut = isMac ? 'Cmd+I' : 'Ctrl+I';
 
+// Show branch name in title if not on main/master
+const isFeatureBranch = GIT_BRANCH && !['main', 'master'].includes(GIT_BRANCH);
+const branchDisplayName = isFeatureBranch ? GIT_BRANCH.replace(/^feature\//, '') : null;
+
 // Header with navigation
 interface HeaderProps {
   onOpenSettings: () => void;
@@ -55,7 +60,15 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ onOpenSettings }) => {
   return (
     <header>
-      <h1>Swing Analyzer</h1>
+      <h1>
+        Swing Analyzer
+        {branchDisplayName && (
+          <span className="branch-indicator" title={`Branch: ${GIT_BRANCH}`}>
+            {' '}
+            [{branchDisplayName}]
+          </span>
+        )}
+      </h1>
       <nav>
         <button
           type="button"
@@ -82,6 +95,15 @@ const AppContent: React.FC = () => {
       onShake: bugReporter.open,
     }
   );
+
+  // Set document title with branch name if on feature branch
+  useEffect(() => {
+    if (branchDisplayName) {
+      document.title = `Swing Analyzer [${branchDisplayName}]`;
+    } else {
+      document.title = 'Swing Analyzer';
+    }
+  }, []);
 
   // Keyboard shortcut: Ctrl+I or Cmd+I to open bug reporter
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Displays the current git branch name in the window title and header when not on main/master branch
- Window/tab title format: "Swing Analyzer [branch-name]"
- Header h1 format: "Swing Analyzer [branch-name]"
- Strips "feature/" prefix for cleaner display
- Uses yellow color (#fbbf24) for visual distinction

## Changes
- Modified `src/components/App.tsx` to detect current branch and update title/header
- Added CSS styling in `src/components/App.css` for branch name display

## Test plan
- [x] Verify branch name appears in window title when on feature branch
- [x] Verify branch name appears in header when on feature branch
- [x] Verify "feature/" prefix is stripped from display
- [x] Verify no branch name shown when on main/master
- [x] Verify yellow color styling is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)