### PR TITLE
fix: Remove auto-play to fix double-play bug for external videos

### DIFF
--- a/e2e-tests/helpers/video.ts
+++ b/e2e-tests/helpers/video.ts
@@ -14,7 +14,7 @@ import type { Page } from '@playwright/test';
 export async function loadHardcodedVideo(page: Page): Promise<void> {
   await page.click('#load-hardcoded-btn');
   await page.waitForSelector(
-    '.status-indicator:has-text("Hardcoded video loaded")',
+    '.status-indicator:has-text("Video loaded")',
     {
       timeout: 15000,
     }
@@ -28,6 +28,9 @@ export async function loadHardcodedVideo(page: Page): Promise<void> {
  */
 export async function loadHardcodedVideoAndPlay(page: Page): Promise<void> {
   await loadHardcodedVideo(page);
+
+  // Click play button to start playback (video no longer auto-plays)
+  await page.click('#play-pause-btn');
 
   // Wait for video to start playing
   await page.waitForFunction(

--- a/src/hooks/useSwingAnalyzer.tsx
+++ b/src/hooks/useSwingAnalyzer.tsx
@@ -580,42 +580,26 @@ export function useSwingAnalyzer(initialState?: Partial<AppState>) {
 
       await frameAcquisitionRef.current.loadVideoFromURL(videoURL);
       setAppState((prev) => ({ ...prev, usingCamera: false }));
-      setStatus('Hardcoded video loaded.');
+      setStatus('Video loaded. Press Play to start.');
 
-      // Make sure the canvas is visible before playing
+      // Make sure the canvas is visible
       if (canvasRef.current) {
         canvasRef.current.style.display = 'block';
       }
 
-      // Force pipeline reset before playing
+      // Force pipeline reset
       if (pipelineRef.current) {
         pipelineRef.current.reset();
       }
 
-      // Video element event handlers will handle pipeline start
-      if (videoRef.current && videoRef.current.readyState >= 2) {
-        videoRef.current.play().catch((err) => {
-          console.error('Error playing hardcoded video:', err);
-        });
-      } else if (videoRef.current) {
-        videoRef.current.addEventListener(
-          'loadeddata',
-          () => {
-            // Reset display mode again just to be safe
-            setDisplayMode(appState.displayMode);
-
-            videoRef.current?.play().catch((err) => {
-              console.error('Error playing hardcoded video after load:', err);
-            });
-          },
-          { once: true }
-        );
-      }
+      // Don't auto-play - let user press Play button manually.
+      // This ensures React effects have time to run and reinitialize
+      // the pipeline with the live pose cache before playback starts.
     } catch (error) {
       console.error('[DEBUG] loadHardcodedVideo: Error loading video:', error);
       setStatus('Error: Could not load hardcoded video.');
     }
-  }, [resetVideoAndState, appState.displayMode, setDisplayMode]);
+  }, [resetVideoAndState]);
 
   // Handle video upload
   const handleVideoUpload = useCallback(
@@ -640,28 +624,12 @@ export function useSwingAnalyzer(initialState?: Partial<AppState>) {
       frameAcquisitionRef.current
         .loadVideoFromURL(fileURL)
         .then(() => {
-          setStatus(`Loaded video: ${file.name}`);
+          setStatus(`Loaded: ${file.name}. Press Play to start.`);
           setAppState((prev) => ({ ...prev, usingCamera: false }));
 
-          // Video element event handlers will handle pipeline start
-          if (videoRef.current && videoRef.current.readyState >= 2) {
-            videoRef.current.play().catch((err) => {
-              console.error('Error playing uploaded video:', err);
-            });
-          } else if (videoRef.current) {
-            videoRef.current.addEventListener(
-              'loadeddata',
-              () => {
-                videoRef.current?.play().catch((err) => {
-                  console.error(
-                    'Error playing uploaded video after load:',
-                    err
-                  );
-                });
-              },
-              { once: true }
-            );
-          }
+          // Don't auto-play - let user press Play button manually.
+          // This ensures React effects have time to run and reinitialize
+          // the pipeline with the live pose cache before playback starts.
         })
         .catch((error) => {
           console.error('Error loading video:', error);


### PR DESCRIPTION
## Summary
- Remove auto-play behavior that caused videos to play twice when loaded from external sources
- Simplifies video loading logic in useSwingAnalyzer hook

## Test plan
- [ ] Load an external video URL and verify it doesn't auto-play twice
- [ ] Load local video file and verify normal playback
- [ ] Run E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed automatic video playback on load. Videos now require manual user action to start playing, providing better control over playback initiation.
  * Updated instructional messages to clarify that users must press Play to begin video playback after loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->