### PR TITLE
Add shared git hooks to block direct pushes to main

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,19 @@
+# Git Hooks
+
+Shared git hooks for this repository.
+
+## Setup
+
+Run this command to use these hooks:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## Hooks
+
+### pre-push
+
+Blocks direct pushes to `main` branch. All changes must go through PRs.
+
+To bypass in emergencies: `git push --no-verify`

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Block direct pushes to main branch
+# All changes to main must go through PRs
+
+protected_branch="main"
+
+while read local_ref local_sha remote_ref remote_sha; do
+    if [[ "$remote_ref" == "refs/heads/$protected_branch" ]]; then
+        echo ""
+        echo "🚫 Direct push to '$protected_branch' is blocked!"
+        echo ""
+        echo "   Per CLAUDE.md: 'Nothing merges without a PR and human approval'"
+        echo ""
+        echo "   Instead:"
+        echo "   1. Create a feature branch: git checkout -b fix/my-change"
+        echo "   2. Push the branch: git push -u origin fix/my-change"
+        echo "   3. Create a PR: gh pr create"
+        echo ""
+        echo "   To bypass (emergencies only): git push --no-verify"
+        echo ""
+        exit 1
+    fi
+done
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,16 @@ See `FULL_PR_PLAN.md` for the project roadmap (also tracked as beads issues).
 
 ## PR Workflow
 
+### Git Hooks Setup
+
+Run this at session start to enable shared hooks:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This blocks direct pushes to `main` - all changes must go through PRs.
+
 ### Branch Strategy
 
 - **feature branches**: Agents work here, one branch per task


### PR DESCRIPTION
## Summary

- Add `.githooks/pre-push` hook that blocks pushes to main branch
- Add setup instructions to CLAUDE.md for agents
- Hooks are shared via repo, agents just need to run:
  ```bash
  git config core.hooksPath .githooks
  ```

This enforces the PR workflow documented in CLAUDE.md: "Nothing merges without a PR and human approval"

## Test plan

- [x] Tested hook locally - blocks push to main with clear error message
- [x] Bypass works with `--no-verify` for emergencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented development workflow improvements to enforce proper code review procedures and prevent accidental direct pushes to the main branch, ensuring code quality through the pull request review process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->