### PR TITLE
Add FPS delay simulation to CachedPoseSkeletonTransformer

### DIFF
--- a/src/pipeline/CachedPoseSkeletonTransformer.ts
+++ b/src/pipeline/CachedPoseSkeletonTransformer.ts
@@ -18,6 +18,7 @@
  */
 
 import { type Observable, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
 import { Skeleton } from '../models/Skeleton';
 import { CocoBodyParts, type PoseKeypoint } from '../types';
 import type { PoseTrackFile, PoseTrackFrame } from '../types/posetrack';
@@ -30,24 +31,45 @@ import type {
 import type { PoseEvent } from './PoseSkeletonTransformer';
 
 /**
+ * Configuration options for CachedPoseSkeletonTransformer
+ */
+export interface CachedPoseSkeletonTransformerConfig {
+  /**
+   * Simulated frames per second for realistic timing.
+   * When set, adds a delay to each frame to simulate real-time processing.
+   * Set to 0 or undefined to disable delay (process as fast as possible).
+   * Default: 15 FPS (typical mobile device performance)
+   */
+  simulatedFps?: number;
+}
+
+/**
  * SkeletonTransformer that uses cached/streaming pose data
  */
 export class CachedPoseSkeletonTransformer implements SkeletonTransformer {
   private cache: LivePoseCache;
   /** Max time difference (seconds) for frame lookup during streaming */
   private streamingTolerance = 0.1; // 100ms - about 3 frames at 30fps
+  /** Delay in ms between frames (0 = no delay) */
+  private frameDelayMs: number;
 
   /**
    * Create from LivePoseCache (streaming mode)
    */
-  constructor(cache: LivePoseCache);
+  constructor(cache: LivePoseCache, config?: CachedPoseSkeletonTransformerConfig);
 
   /**
    * Create from static PoseTrackFile (static mode)
    */
-  constructor(poseTrack: PoseTrackFile);
+  constructor(poseTrack: PoseTrackFile, config?: CachedPoseSkeletonTransformerConfig);
 
-  constructor(cacheOrPoseTrack: LivePoseCache | PoseTrackFile) {
+  constructor(
+    cacheOrPoseTrack: LivePoseCache | PoseTrackFile,
+    config?: CachedPoseSkeletonTransformerConfig
+  ) {
+    // Calculate frame delay from FPS (default 15 FPS = ~67ms per frame)
+    const fps = config?.simulatedFps ?? 15;
+    this.frameDelayMs = fps > 0 ? Math.round(1000 / fps) : 0;
 
     if (cacheOrPoseTrack instanceof LivePoseCache) {
       this.cache = cacheOrPoseTrack;
@@ -57,7 +79,8 @@ export class CachedPoseSkeletonTransformer implements SkeletonTransformer {
     }
 
     console.log(
-      `CachedPoseSkeletonTransformer: Initialized with ${this.cache.getFrameCount()} frames`
+      `CachedPoseSkeletonTransformer: Initialized with ${this.cache.getFrameCount()} frames, ` +
+        `simulated ${fps} FPS (${this.frameDelayMs}ms delay)`
     );
   }
 
@@ -81,6 +104,9 @@ export class CachedPoseSkeletonTransformer implements SkeletonTransformer {
    *
    * After extraction complete:
    * - Uses closest available frame regardless of distance
+   *
+   * When simulatedFps is configured, adds a delay to simulate real-time
+   * frame processing (helps catch timing bugs in UI like filmstrip rep counter).
    */
   transformToSkeleton(frameEvent: FrameEvent): Observable<SkeletonEvent> {
     const videoTime = frameEvent.videoTime ?? 0;
@@ -92,9 +118,11 @@ export class CachedPoseSkeletonTransformer implements SkeletonTransformer {
     const cachedFrame = this.cache.getFrame(videoTime, tolerance);
 
     if (cachedFrame) {
-      // Frame available within tolerance - return immediately
+      // Frame available within tolerance
       this.frameStats.used++;
-      return of(this.buildSkeletonEvent(cachedFrame, frameEvent));
+      const result = of(this.buildSkeletonEvent(cachedFrame, frameEvent));
+      // Apply simulated frame delay if configured
+      return this.frameDelayMs > 0 ? result.pipe(delay(this.frameDelayMs)) : result;
     }
 
     // No frame within tolerance
@@ -120,10 +148,12 @@ export class CachedPoseSkeletonTransformer implements SkeletonTransformer {
     // During streaming, we just skip this frame - extraction hasn't caught up yet
     // Don't wait because switchMap would cancel the wait anyway when new frames arrive
 
-    return of({
+    const nullResult = of({
       skeleton: null,
       poseEvent: this.createPoseEvent(null, frameEvent),
     });
+    // Apply simulated frame delay even for null results to maintain consistent timing
+    return this.frameDelayMs > 0 ? nullResult.pipe(delay(this.frameDelayMs)) : nullResult;
   }
 
   /**

--- a/src/pipeline/PipelineFactory.ts
+++ b/src/pipeline/PipelineFactory.ts
@@ -1,5 +1,8 @@
 import type { PoseTrackFile } from '../types/posetrack';
-import { CachedPoseSkeletonTransformer } from './CachedPoseSkeletonTransformer';
+import {
+  CachedPoseSkeletonTransformer,
+  type CachedPoseSkeletonTransformerConfig,
+} from './CachedPoseSkeletonTransformer';
 import type { LivePoseCache } from './LivePoseCache';
 import { Pipeline } from './Pipeline';
 import type {
@@ -29,6 +32,14 @@ export interface CreatePipelineOptions {
    * with blocking waits for frames not yet extracted.
    */
   livePoseCache?: LivePoseCache;
+
+  /**
+   * Simulated frames per second for cached pose playback.
+   * When set, adds a delay between frames to simulate real-time processing.
+   * Default: 15 FPS (typical mobile device performance).
+   * Set to 0 to disable delay and process as fast as possible.
+   */
+  simulatedFps?: number;
 }
 
 /**
@@ -49,15 +60,22 @@ export function createPipeline(
   // Choose skeleton transformer based on available cache options
   let skeletonTransformer: SkeletonTransformer;
 
+  // Build config for cached transformer (default 15 FPS simulation)
+  const cachedConfig: CachedPoseSkeletonTransformerConfig = {
+    simulatedFps: options.simulatedFps ?? 15,
+  };
+
   if (options.livePoseCache) {
     // Streaming mode: use LivePoseCache with blocking waits
     skeletonTransformer = new CachedPoseSkeletonTransformer(
-      options.livePoseCache
+      options.livePoseCache,
+      cachedConfig
     );
   } else if (options.cachedPoseTrack) {
     // Static mode: use pre-loaded PoseTrackFile
     skeletonTransformer = new CachedPoseSkeletonTransformer(
-      options.cachedPoseTrack
+      options.cachedPoseTrack,
+      cachedConfig
     );
   } else {
     // ML mode: use real-time ML inference
@@ -114,9 +132,13 @@ export function createRepProcessor(): RepProcessor {
 /**
  * Create a cached skeleton transformer component
  * Uses pre-extracted pose data instead of ML inference
+ *
+ * @param poseTrack - Pre-extracted pose data
+ * @param config - Optional configuration (default: 15 FPS simulation)
  */
 export function createCachedSkeletonTransformer(
-  poseTrack: PoseTrackFile
+  poseTrack: PoseTrackFile,
+  config?: CachedPoseSkeletonTransformerConfig
 ): SkeletonTransformer {
-  return new CachedPoseSkeletonTransformer(poseTrack);
+  return new CachedPoseSkeletonTransformer(poseTrack, config ?? { simulatedFps: 15 });
 }


### PR DESCRIPTION
## Summary

Add simulated frame delay to make cached pose playback timing match real-world device performance (~15 FPS default).

This helps:
- Tests run closer to actual user experience
- Debug timing issues like filmstrip rep counter
- Catch race conditions that only appear at realistic frame rates

## Changes

- Add `CachedPoseSkeletonTransformerConfig` with `simulatedFps` option
- Add RxJS `delay()` operator to `transformToSkeleton` for realistic timing
- Update `PipelineFactory` to accept `simulatedFps` option (default 15)
- Delay applies to both successful and null frame results

The default 15 FPS adds ~67ms delay per frame, simulating typical mobile device pose detection performance.

## Usage

```typescript
// Default: 15 FPS simulation
const pipeline = createPipeline(video, canvas, { cachedPoseTrack });

// Custom FPS
const pipeline = createPipeline(video, canvas, { cachedPoseTrack, simulatedFps: 30 });

// No delay (process as fast as possible)
const pipeline = createPipeline(video, canvas, { cachedPoseTrack, simulatedFps: 0 });
```

## Test plan

- [x] All existing unit tests pass (63/63)
- [x] Type checking passes
- [ ] Manual testing with filmstrip to verify rep counter timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable simulated frame rate for cached pose skeleton processing, enabling controlled playback timing of recorded pose sequences.
  * Frame-level delay can now be customized during pipeline creation (default 15 FPS; 0 disables delay).
  * Timing delay is consistently applied across all frame retrieval scenarios to maintain accurate playback synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->