### PR TITLE
UI: Simplify rep nav strip - show only phase with bigger buttons

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -240,10 +240,10 @@ main {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: 56px;
+  min-height: 56px;
   border: none;
-  border-radius: 10px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.1);
   color: rgba(255, 255, 255, 0.8);
   cursor: pointer;
@@ -315,18 +315,14 @@ main {
   }
 
   .rep-nav-btn {
-    min-width: 40px;
-    min-height: 40px;
+    min-width: 48px;
+    min-height: 48px;
   }
 
   .rep-nav-display {
     padding: 0 8px;
     font-size: 0.875rem;
     gap: 4px;
-  }
-
-  .rep-nav-position {
-    font-size: 0.8125rem;
   }
 }
 

--- a/src/components/VideoSectionV2.test.tsx
+++ b/src/components/VideoSectionV2.test.tsx
@@ -464,7 +464,9 @@ describe('VideoSectionV2', () => {
         })
       );
       render(<VideoSectionV2 />);
-      expect(screen.getByText('Rep 1/2')).toBeInTheDocument();
+      // Rep navigation strip shows phase and navigation buttons
+      expect(screen.getByLabelText('Previous rep')).toBeInTheDocument();
+      expect(screen.getByLabelText('Next rep')).toBeInTheDocument();
     });
   });
 

--- a/src/components/VideoSectionV2.tsx
+++ b/src/components/VideoSectionV2.tsx
@@ -233,12 +233,8 @@ const VideoSectionV2: React.FC = () => {
             </button>
           </div>
 
-          {/* Center: Rep and checkpoint display */}
+          {/* Center: Phase display */}
           <span className="rep-nav-display">
-            <span className="rep-nav-label">
-              Rep {appState.currentRepIndex + 1}/{repCount}
-            </span>
-            <span className="rep-nav-dot">•</span>
             <span className="rep-nav-position">
               {currentPosition
                 ? PHASE_LABELS[currentPosition] || currentPosition


### PR DESCRIPTION
## Summary
- Remove "Rep X/Y" display from navigation strip, show only phase name (Top, Bottom, Connect, Release)
- Increase navigation button size to 56x56px on desktop, 48x48px on mobile for better touch targets

## Test plan
- [x] Unit tests pass (432 tests)
- [x] TypeScript compiles cleanly
- [ ] Visual verification of nav strip layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased button sizes across the interface for improved accessibility and touch targets, making elements easier to interact with.
  * Refined border-radius styling for button elements.
  * Removed obsolete CSS rules.
  * Updated video playback display to show phase information instead of rep progress.

* **Tests**
  * Updated navigation button test assertions to verify button presence and correct labeling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->